### PR TITLE
add docker-exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@
 
    `docker run  --name syslog -d -v /tmp/syslogdev:/dev syslog`
 
-3. Tail them logs: 
+3. Start another container to send logs:
+
+   `docker run -v /tmp/syslogdev/log:/dev/log ubuntu logger hello`
+   
+4. (a) Tail them logs: 
 
    `docker run --volumes-from syslog ubuntu tail -f /var/log/syslog`
 
-4. Start another container to send logs:
-
-   `docker run -v /tmp/syslogdev/log:/dev/log ubuntu logger hello`
+4. (b) *Alternatively*, as of docker v1.3 use the `docker-exec` command to inspect syslog container directly
+    
+    `docker exec -t syslog tail -f /var/log/syslog`
 
 5. See in the log message show up in the "tail" container.
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@
 
    `docker build -t syslog .`
 
-2. Run it: 
+2. Monitor the logs: 
+
+   `docker run --volumes-from syslog ubuntu tail -f /var/log/syslog`
+   
+3. Run it: 
 
    `docker run  --name syslog -d -v /tmp/syslogdev:/dev syslog`
 
-3. Start another container to send logs:
+4. Start another container to send logs:
 
    `docker run -v /tmp/syslogdev/log:/dev/log ubuntu logger hello`
-   
-4. (a) Tail them logs: 
 
-   `docker run --volumes-from syslog ubuntu tail -f /var/log/syslog`
 
-4. (b) *Alternatively*, as of docker v1.3 use the `docker-exec` command to inspect syslog container directly
+5. *Alternative to #2*, as of docker v1.3 use the `docker-exec` command to inspect syslog container directly, after some logs have been generated
     
     `docker exec -t syslog tail -f /var/log/syslog`
 


### PR DESCRIPTION
- remove the need for a third container with docker-exec to inspect
- for clarity, change step order, i.e. send some logs first then inspect the logs...