### PR TITLE
Add link to background blog post to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@
 
 5. See in the log message show up in the "tail" container.
 
+## Background
+
+For more information on this approach, see [Multiple Docker containers logging to a single syslog](http://jpetazzo.github.io/2014/08/24/syslog-docker/).


### PR DESCRIPTION
The blog post that led me to this repository is very useful information for understanding the purpose of this image and why you'd use it. This change makes it easy to find for people that come across this repository another way, or want to keep track of the information there when revisiting this repository later.
